### PR TITLE
Fix to send and receive talk sequentially

### DIFF
--- a/src/components/PipingChat.vue
+++ b/src/components/PipingChat.vue
@@ -387,20 +387,20 @@ export default class PipingChat extends Vue {
           kind: "talk",
           content: encryptedTalk,
         };
-        const res = await this.sendSeqCtx.run(() =>
-          fetch(url, {
+        await this.sendSeqCtx.run(async () => {
+          const res = await fetch(url, {
             method: "POST",
             body: JSON.stringify(parcel)
-          })
-        );
-        if(res.body === null) {
-          this.echoSystemTalk("Unexpected error: send-body is null.");
-        } else {
-          // Wait for body being complete
-          await res.body.pipeTo(new WritableStream({}));
-          // Set arrived as true
-          userTalk.arrived = true;
-        }
+          });
+          if (res.body === null) {
+            this.echoSystemTalk("Unexpected error: send-body is null.");
+          } else {
+            // Wait for body being complete
+            await res.body.pipeTo(new WritableStream({}));
+            // Set arrived as true
+            userTalk.arrived = true;
+          }
+        });
       }
     })();
   }

--- a/src/components/PipingChat.vue
+++ b/src/components/PipingChat.vue
@@ -54,6 +54,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 import TimeAgo from 'vue2-timeago'
 import * as jsencrypt from 'jsencrypt';
 import * as cryptojs from 'crypto-js';
+import{ PromiseSequentialContext } from "@/promise-sequential-context";
 
 type ParcelKind = "rsa_key" | "talk"
 
@@ -188,6 +189,9 @@ export default class PipingChat extends Vue {
   // Whether peer's public key received or not
   private hasPeerPublicKeyReceived: boolean = false;
 
+  private recieveSeqCtx = new PromiseSequentialContext();
+  private sendSeqCtx    = new PromiseSequentialContext();
+
   private echoSystemTalk(message: string): void {
     this.talks.unshift({
       kind: "system",
@@ -274,10 +278,12 @@ export default class PipingChat extends Vue {
         kind: "rsa_key",
         content: this.publicKey,
       };
-      const res = await fetch(url, {
-        method: "POST",
-        body: JSON.stringify(parcel)
-      });
+      const res = await this.sendSeqCtx.run(()=>
+        fetch(url, {
+          method: "POST",
+          body: JSON.stringify(parcel)
+        })
+      );
 
       this.echoSystemTalk("Your public key sent.");
       this.hasPublicKeySent = true;
@@ -291,9 +297,11 @@ export default class PipingChat extends Vue {
       while(true) {
         try {
           console.log(`Getting ${url}...`);
-          const res = await fetch(url, {
-            method: "GET"
-          });
+          const res = await this.recieveSeqCtx.run(()=>
+            fetch(url, {
+              method: "GET"
+            })
+          );
 
           if(res.body === null) {
             console.log("ERROR: Body not found");
@@ -379,10 +387,12 @@ export default class PipingChat extends Vue {
           kind: "talk",
           content: encryptedTalk,
         };
-        const res = await fetch(url, {
-          method: "POST",
-          body: JSON.stringify(parcel)
-        });
+        const res = await this.sendSeqCtx.run(() =>
+          fetch(url, {
+            method: "POST",
+            body: JSON.stringify(parcel)
+          })
+        );
         if(res.body === null) {
           this.echoSystemTalk("Unexpected error: send-body is null.");
         } else {

--- a/src/promise-sequential-context.ts
+++ b/src/promise-sequential-context.ts
@@ -1,0 +1,16 @@
+/**
+ * Sequential context for promises which is like synchronize in Java
+ *
+ * In this context, previous promises run first
+ */
+export class PromiseSequentialContext {
+  prev: Promise<any> = Promise.resolve();
+  run<T>(asyncFunc: ()=>Promise<T>): Promise<T> {
+    this.prev = this.prev.then(()=>{
+      return asyncFunc();
+    }).catch(()=>{
+      return asyncFunc();
+    });
+    return this.prev;
+  }
+}


### PR DESCRIPTION
## Fixed
* Fix to send and receive talk sequentially

Before this PR, clicking [send] button just calls `fetch(..., {method: "POST"})`. So, when users click multiple times in short, requests are like `fetch();fetch();fetch();fetch();...`. However, Piping Server rejects already connected path if connection is not finished. So, this PR solve this issue.

The fixation chages calls by user's click like `await fetch(); await fetch(); await fetch();...`. The new `fetch` waits for previous `fetch` being finished. `PromiseSequentialContext` class is core implementation of this logic.