### PR TITLE
Implement public key authentication like SSH

### DIFF
--- a/src/components/PipingChat.vue
+++ b/src/components/PipingChat.vue
@@ -20,7 +20,8 @@
           <button v-on:click="erasePrivateKey()">Erase private key from storage</button>
         </details>
         <h4>Peer's public RSA PEM</h4>
-        <textarea cols="80" rows="8" v-model="peerPublicSignPem"></textarea>
+        <textarea cols="80" rows="8" v-model="peerPublicSignPem"></textarea><br>
+        Session ID: <input type="text" v-bind:value="sessionId" disabled size="70">
 
         <details>
           <summary>For encryption</summary>
@@ -251,7 +252,7 @@ export default class PipingChat extends Vue {
   );
 
   // Session ID
-  public sessionId?: string;
+  public sessionId: string = '';
   // Whether peer is verified by public key authentication
   public peerVerified: boolean = false;
 

--- a/src/components/PipingChat.vue
+++ b/src/components/PipingChat.vue
@@ -75,10 +75,8 @@ import * as utils from '@/utils';
 import { jwk2pem } from 'pem-jwk';
 
 
-// TODO: Should rename
-interface EcdhPublicJwkParcel {
-  // TODO: Should rename kind
-  kind: 'ecdh_public_jwk';
+interface KeyExchangeParcel {
+  kind: 'key_exchange';
   content: {
     // Public key for session ID generation
     sessionIdPublicJwk: JsonWebKey,
@@ -92,7 +90,7 @@ interface TalkParcel {
   content: string;
 }
 
-type Parcel = EcdhPublicJwkParcel | TalkParcel;
+type Parcel = KeyExchangeParcel | TalkParcel;
 
 interface UserTalk {
   kind: 'user';
@@ -139,7 +137,7 @@ function parseJsonToParcel(json: any): Parcel | undefined {
     return undefined;
   }
   switch (json.kind) {
-    case 'ecdh_public_jwk':
+    case 'key_exchange':
     case 'talk':
       return {
         kind: json.kind,
@@ -380,8 +378,8 @@ export default class PipingChat extends Vue {
     //   }
     // })();
 
-    const parcel: EcdhPublicJwkParcel = {
-      kind: 'ecdh_public_jwk',
+    const parcel: KeyExchangeParcel = {
+      kind: 'key_exchange',
       content: {
         sessionIdPublicJwk,
         encryptPublicJwk,
@@ -469,7 +467,7 @@ export default class PipingChat extends Vue {
         }
 
         switch (parcel.kind) {
-          case 'ecdh_public_jwk':
+          case 'key_exchange':
             // Set peer's public JWK
             const peerPublicJwk: JsonWebKey = parcel.content.encryptPublicJwk;
             console.log('Peer\'s public JWK:', peerPublicJwk);

--- a/src/components/PipingChat.vue
+++ b/src/components/PipingChat.vue
@@ -155,17 +155,6 @@ function parseJsonToParcel(json: any): Parcel | undefined {
   }
 }
 
-
-// TODO: Remove
-// (NOTE: The reason not to use JSON.stringify() is that I'm not sure the order of items is always same.)
-// TODO: Remove it and Use JWK thumbprint instead
-function getSignDataFromJwk(jwk: JsonWebKey): string {
-  // JSON string sorted by keys
-  // (from: https://stackoverflow.com/a/16168003/2885946)
-  return JSON.stringify(jwk, Object.keys(jwk));
-}
-
-
 // (NOTE: The reason not to use JSON.stringify() is that I'm not sure the order of items is always same.)
 // TODO: Remove it and Use JWK thumbprint instead
 function getPoorJwkFingerprint(jwk: JsonWebKey): string {
@@ -280,7 +269,7 @@ export default class PipingChat extends Vue {
   public readonly aesGcmIvLength: number = 12;
 
   // Whether using signature to verify peer
-  public enableSignature = true; // TODO: false
+  public enableSignature = false;
   // Private PEM only for signature
   public privateSignPem = '';
   // Peer's public PEM for signature

--- a/src/components/PipingChat.vue
+++ b/src/components/PipingChat.vue
@@ -367,24 +367,6 @@ export default class PipingChat extends Vue {
 
     const url = `${this.serverUrl}/${getPath(this.talkerId, this.peerId)}`;
 
-    // // Signature of public encryption JWK
-    // const signature: string | undefined = await (async () => {
-    //   if (this.enableSignature) {
-    //     // Get private key by PEM
-    //     const { privateKey } = await utils.privRsaPemToPubPrivKeys(this.signAlg, this.privateSignPem);
-    //     // Sign
-    //     const signatureBuff: ArrayBuffer = await window.crypto.subtle.sign(
-    //       this.signAlg,
-    //       privateKey,
-    //       utils.stringToArrayBuffer(getSignDataFromJwk(publicJwk)),
-    //     );
-    //     // Base64 encode
-    //     return btoa(utils.arrayBufferToString(signatureBuff));
-    //   } else {
-    //     return undefined;
-    //   }
-    // })();
-
     const parcel: KeyExchangeParcel = {
       kind: 'key_exchange',
       content: {
@@ -485,42 +467,6 @@ export default class PipingChat extends Vue {
               (await this.sessionIdKeyPairPromise).privateKey,
             );
             console.log('Session ID:', this.sessionId);
-
-            // // If signature connection is enable
-            // if (this.enableSignature) {
-            //   const signature =  parcel.content.signature;
-            //   // If no signature
-            //   if (signature === undefined) {
-            //     this.echoSystemTalk('Error: establishment failed because peer has no signature');
-            //     break;
-            //   }
-            //
-            //   // Decode base64
-            //   const signatureBuff: ArrayBuffer = utils.stringToArrayBuffer(atob(signature));
-            //
-            //   // Get peer's public key
-            //   const peerPublicKey = await utils.pubRsaPemToPubKey(this.signAlg, this.peerPublicSignPem);
-            //
-            //   // Peer's JWK
-            //   const signData: ArrayBuffer = utils.stringToArrayBuffer(getSignDataFromJwk(peerPublicJwk));
-            //
-            //   const verified = await window.crypto.subtle.verify(
-            //     this.signAlg,
-            //     peerPublicKey,
-            //     signatureBuff,
-            //     signData,
-            //   );
-            //
-            //   console.log('verified:', verified);
-            //
-            //   if (verified) {
-            //     this.echoSystemTalk('Peer was verified!');
-            //   } else {
-            //     this.echoSystemTalk('Error: Peer was not verified.');
-            //     this.echoSystemTalk('Error: Connection was not established.');
-            //     break;
-            //   }
-            // }
 
             // Assign peer's public JWK by import
             this.peerEncryptPublicCryptoKey = await crypto.subtle.importKey(


### PR DESCRIPTION
## Changed
* Implement public key authentication like SSH

## Specification
This PR introduces public key authentication like SSH.

1. Exchange public keys by ECDH
   - One of the keys (= `Pub_SK`) is for session ID generation
   - The other key (= `Pub_EK`) is for encrypting the connection
1. Generate private key (=`Priv_EK`) by `Pub_EK`
1. All communication is encrypted by `Priv_EK` after the key exchange above
1. The private key (= `Priv_SK`) is calculated by the peer's public ECDH key (=`Pub_SK`) for session ID generation
1. The session ID is calculated by `SHA256(JWK(Priv_SK))`
1. Sign the session ID by my private RSA key, and send the signature to the peer
1. The peer verifies the session ID signature by my public RSA key.

## References
* Japanese: <https://qiita.com/angel_p_57/items/2e3f3f8661de32a0d432>
* <https://www.rfc-editor.org/rfc/rfc4252.txt>
* Session ID generation in SSH: <https://security.stackexchange.com/questions/120947/ssh-session-id-in-rfc-4253-key-exchange/120972#120972>